### PR TITLE
Fixed a small typo that pointed to a broken link

### DIFF
--- a/weave-loadbalance/README.md
+++ b/weave-loadbalance/README.md
@@ -43,7 +43,7 @@ You will use Weave to
 
 ## Configuring and setting up your hosts ##
 
-All of the code for this example is available on [github](http://github.com/weaveworks/buides), and you first clone the getting started repository.
+All of the code for this example is available on [github](http://github.com/weaveworks/guides), and you first clone the getting started repository.
 
     git clone http://github.com/weaveworks/guides
 


### PR DESCRIPTION
There's a broken link in the weave-loadbalance guide, `b` is close to `g` in the keyboard :)
