### PR TITLE
Update range notation in line with weave #1636

### DIFF
--- a/centos-simple/README.md
+++ b/centos-simple/README.md
@@ -147,7 +147,7 @@ View the peered network by running `weave status`:
 
        Service: ipam
      Consensus: deferred
-         Range: [10.32.0.0-10.48.0.0)
+         Range: 10.32.0.0-10.47.255.255
  DefaultSubnet: 10.32.0.0/12
 
        Service: dns

--- a/microservices-seneca-ubuntu-simple/README.md
+++ b/microservices-seneca-ubuntu-simple/README.md
@@ -138,7 +138,7 @@ vagrant@weave-gs-02:~$ weave status
 
        Service: ipam
      Consensus: deferred
-         Range: [10.2.1.0-10.2.2.0)
+         Range: 10.2.1.0-10.2.1.255
  DefaultSubnet: 10.2.1.0/24
 
        Service: dns

--- a/rails-ubuntu-simple/README.md
+++ b/rails-ubuntu-simple/README.md
@@ -253,7 +253,7 @@ Version: 1.1.1
 
        Service: ipam
      Consensus: achieved
-         Range: [10.32.0.0-10.48.0.0)
+         Range: 10.32.0.0-10.47.255.255
  DefaultSubnet: 10.32.0.0/12
 
        Service: dns

--- a/spring-boot-weave-service-discovery/README.md
+++ b/spring-boot-weave-service-discovery/README.md
@@ -145,7 +145,7 @@ $ weave status
 
        Service: ipam
      Consensus: deferred
-         Range: [10.32.0.0-10.48.0.0)
+         Range: 10.32.0.0-10.47.255.255
  DefaultSubnet: 10.32.0.0/12
 
        Service: dns

--- a/ubuntu-simple/README.md
+++ b/ubuntu-simple/README.md
@@ -129,7 +129,7 @@ Version: v1.1.0
 
        Service: ipam
      Consensus: deferred
-         Range: [10.32.0.0-10.48.0.0)
+         Range: 10.32.0.0-10.47.255.255
  DefaultSubnet: 10.32.0.0/12
 
        Service: dns

--- a/weave-and-docker-platform/1-machine.md
+++ b/weave-and-docker-platform/1-machine.md
@@ -110,7 +110,7 @@ Version: v1.2
 
        Service: ipam
      Consensus: deferred
-         Range: [10.32.0.0-10.48.0.0)
+         Range: 10.32.0.0-10.47.255.255
  DefaultSubnet: 10.32.0.0/12
 
        Service: dns

--- a/weave-loadbalance/README.md
+++ b/weave-loadbalance/README.md
@@ -124,7 +124,7 @@ Log on to either one of the hosts and type `weave status` to view the Weave comp
 
        Service: ipam
      Consensus: deferred
-         Range: [10.2.0.0-10.3.0.0)
+         Range: 10.2.0.0-10.2.255.255
  DefaultSubnet: 10.2.0.0/16
 
        Service: dns


### PR DESCRIPTION
This change should not be merged until https://github.com/weaveworks/weave/pull/1636 is released (currently scheduled for 1.3)

We're cheating slightly, in that the weave version shows "1.1" in most examples, and that version still prints the old notation, but the use of "[..)" confused some people.
