### PR TITLE
Update all docs.weave.works links to point to docs in WordPress

### DIFF
--- a/aws-ecs/README.md
+++ b/aws-ecs/README.md
@@ -405,7 +405,7 @@ Add inbound rules to the group to allow:
 * Private Weave access between instances:
     * tcp port 6783 for data.
     * udp port 6783 for control in sleeve mode.
-    * udp port 6784 for control in [fastdp](http://docs.weave.works/weave/latest_release/features.html#fast-data-path) mode.
+    * udp port 6784 for control in [fastdp](/documentation/net-1.5-features#fast-data-path) mode.
 * Public and private access to Weave Scope between instances (tcp port 4040) . This is Only needed when not using Scope 'Cloud').
 
 ~~~bash
@@ -521,4 +521,4 @@ You can easily adapt these examples and use them as a templates in your own impl
 
 * [Automatic Discovery with weavedns](https://github.com/weaveworks/weave/blob/master/site/weavedns.md)
 * [Weave - Weaving Containers into Applications](https://github.com/weaveworks/weave)
-* [Documentation Home Page](http://docs.weave.works/weave/latest_release/)
+* [Documentation Home Page](/docs)

--- a/aws-nginx-ubuntu-simple/README.md
+++ b/aws-nginx-ubuntu-simple/README.md
@@ -71,7 +71,7 @@ subsititue the relevant IP address for $WEAVE_AWS_DEMO_HOST1 or 2.
 
 ## Introducing the `weavedns` Service ##
 
-[Weavedns](http://docs.weave.works/weave/latest_release/weavedns.html) answers name queries on a Weave container network. `Weavedns` provides a simple way for containers to find each other: just give them hostnames and tell other containers to connect to those names. Unlike Docker 'links', this requires no code changes and works across hosts.
+[WeaveDNS](/documentation/net-1.5-weavedns) answers name queries on a Weave container network. `Weavedns` provides a simple way for containers to find each other: just give them hostnames and tell other containers to connect to those names. Unlike Docker 'links', this requires no code changes and works across hosts.
 
 In this example you will give each container a hostname and use the `weavedns` service to allow Nginx to find the correct container for a request.
 

--- a/centos-simple/README.md
+++ b/centos-simple/README.md
@@ -10,7 +10,7 @@ sidebarpath: /start/wd/centos
 sidebarweight: 15
 ---
 
-In this example you will use `Weave Net` to provide nework connectivity and service discovery using the [`weavedns service`](http://docs.weave.works/weave/latest_release/weavedns.html). 
+In this example you will use `Weave Net` to provide nework connectivity and service discovery using the [WeaveDNS service](/documentation/net-1.5-weavedns). 
 
 In this example:
 
@@ -112,7 +112,7 @@ The two hosts are now connected to each other, and any subsequent containers lau
 
 Since this is the first time launching Weave you have downloaded several docker images containing the Weave components: Weave Router, WeaveDNS, Weave Docker API Proxy and the Docker Network Plugin.
 
->Note: See [Weave Plugin](http://docs.weave.works/weave/latest_release/plugin.html) for information on configuring and setting this up. 
+>Note: See [Weave Plugin](/documentation/net-1.5-plugin) for information on configuring and setting this up. 
 
 On the first host, `weave-gs-01`, you launched a Weave router container. On the second host, `weave-gs-02`, you launched another Weave router container using the IP address of your first host. This command tells the Weave on `weave-gs-02` to peer with the Weave on `weave-gs-01`.
 
@@ -225,7 +225,7 @@ You can adapt this example and use it as a template for your own implementation.
 
 ##Further Reading
 
- * [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
- * [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
- * [Weave Plugin](http://docs.weave.works/weave/latest_release/plugin.html)
- * [`weavedns service`](http://docs.weave.works/weave/latest_release/weavedns.html)
+ * [How Weave Works](/documentation/net-1.5-router-topology)
+ * [Weave Features](/documentation/net-1.5-features)
+ * [Weave Plugin](/documentation/net-1.5-plugin)
+ * [WeaveDNS service](/documentation/net-1.5-weavedns)

--- a/coreos-simple/README.md
+++ b/coreos-simple/README.md
@@ -10,7 +10,7 @@ sidebarpath: /start/wd/coreos
 sidebarweight: 15
 ---
 
-In this example you will use `Weave Net` to provide nework connectivity and service discovery using the [`weavedns service`](http://docs.weave.works/weave/latest_release/weavedns.html). 
+In this example you will use `Weave Net` to provide nework connectivity and service discovery using the [WeaveDNS service](/documentation/net-1.5-weavedns). 
 
 1. You will create a simple containerized web service that runs in on weave-gs-01.
 2. On weave-gs-02, we will deploy a second container that enables you to query the web service on weave-gs-01.
@@ -182,11 +182,11 @@ Now you can exit from the container. As you have finished the command that the c
 
 ## Conclusions ##
 
-In this example, we deployed a simple application, that returns a message from a running Apache webserver. With Weave, you quickly deployed two containers to the network residing on different hosts. These containers were made discoverable using [`weavedns`](http://docs.weave.works/weave/latest_release/weavedns.html), so that applications within containers can communicate with one another. 
+In this example, we deployed a simple application, that returns a message from a running Apache webserver. With Weave, you quickly deployed two containers to the network residing on different hosts. These containers were made discoverable using [WeaveDNS](/documentation/net-1.5-weavedns), so that applications within containers can communicate with one another. 
 
 You can adapt this example and use it as a template for your own implementation. We would be very happy to hear any of your thoughts or issues via [Help and Support](http://weave.works/help/index.html).
 
 ##Further Reading
 
- * [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
- * [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
+ * [How Weave Works](/documentation/net-1.5-router-topology)
+ * [Weave Features](/documentation/net-1.5-features)

--- a/kubernetes/coreos/README.md
+++ b/kubernetes/coreos/README.md
@@ -12,7 +12,7 @@ sidebarweight: 60
 
 Kubernetes is an open source container cluster manager built by Google. It allows you to manage multiple clusters spread across multiple machines. With Kubernetes there is the concept of the pod, which represents a collection of containers deployed as a single logical unit. For more information see the [Kubernetes Overview](http://kubernetes.io/v1.0/docs/user-guide/overview.html)
 
-In this example, we will demonstrate how you can use a Weave network with Kubernetes on a CoreOS cluster. Although there are other network fabric solutions such as [Flannel](https://coreos.com/flannel/docs/latest/flannel-config.html) and [Calico](http://www.projectcalico.org/), only Weave provides simple to deploy [encryption](http://docs.weave.works/weave/latest_release/features.html#security) and automatic unique IP assigment using [IPAM](http://docs.weave.works/weave/latest_release/features.html#addressing). Weave furthermore, is one of the few solutions that can integrate with any uncontainerized services that you may have, such as legacy databases, together on a container network.
+In this example, we will demonstrate how you can use a Weave network with Kubernetes on a CoreOS cluster. Although there are other network fabric solutions such as [Flannel](https://coreos.com/flannel/docs/latest/flannel-config.html) and [Calico](http://www.projectcalico.org/), only Weave provides simple to deploy [encryption](/documentation/net-1.5-features#security) and automatic unique IP assigment using [IPAM](/documentation/net-1.5-features#addressing). Weave furthermore, is one of the few solutions that can integrate with any uncontainerized services that you may have, such as legacy databases, together on a container network.
 
 In this example we will:
 
@@ -161,8 +161,8 @@ You can easily adapt this example and use it as a template for your own implemen
 ##Further Reading
 
 
-* [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
-* [Weave encryption](http://docs.weave.works/weave/latest_release/features.html#security)
-* [Weave IPAM](http://docs.weave.works/weave/latest_release/features.html#addressing)
+* [Weave Features](/documentation/net-1.5-features)
+* [Weave encryption](/documentation/net-1.5-features#security)
+* [Weave IPAM](/documentation/net-1.5-features#addressing)
 * [Weave - Weaving Containers into Applications](https://github.com/weaveworks/weave)
-* [Documentation Home Page](http://docs.weave.works/weave/latest_release/)
+* [Documentation Home Page](/docs)

--- a/kubernetes/coreos/kubernetes-cluster.yaml
+++ b/kubernetes/coreos/kubernetes-cluster.yaml
@@ -100,7 +100,7 @@ coreos:
         After=docker.service
         Before=weave.service
         Description=Install Weave
-        Documentation=http://docs.weave.works/
+        Documentation=http://weave.works/docs
         Requires=network-online.target
         [Service]
         EnvironmentFile=-/etc/weave.%H.env
@@ -127,7 +127,7 @@ coreos:
         After=install-weave.service
         After=docker.service
         Description=Weave proxy for Docker API
-        Documentation=http://docs.weave.works/
+        Documentation=http://weave.works/docs
         Requires=docker.service
         Requires=install-weave.service
         [Service]
@@ -147,7 +147,7 @@ coreos:
         After=install-weave.service
         After=docker.service
         Description=Weave Network Router
-        Documentation=http://docs.weave.works/
+        Documentation=http://weave.works/docs
         Requires=docker.service
         Requires=install-weave.service
         [Service]
@@ -168,7 +168,7 @@ coreos:
         After=install-weave.service
         After=weave.service
         After=docker.service
-        Documentation=http://docs.weave.works/
+        Documentation=http://weave.works/docs
         Requires=docker.service
         Requires=install-weave.service
         Requires=weave.service

--- a/mesos-marathon/centos/README.md
+++ b/mesos-marathon/centos/README.md
@@ -164,7 +164,7 @@ You should see output similar to this:
     </center></body></html>
 
 
-Run `curl -v outyet:8080` several times to confirm that Weave Net is balancing the load. You will notice that the IP address for `outyet` is not always the same and instead is randomized by weavedns as it balances the load between the hosts. For more information on weavedns see [Automatic Discovery with WeaveDNS](http://docs.weave.works/weave/latest_release/weavedns.html).
+Run `curl -v outyet:8080` several times to confirm that Weave Net is balancing the load. You will notice that the IP address for `outyet` is not always the same and instead is randomized by weavedns as it balances the load between the hosts. For more information on weavedns see [Discovering Containers with WeaveDNS](/documentation/net-1.5-weavedns).
 
 
 ### Overriding Default Configuration Variables
@@ -196,8 +196,8 @@ You can easily adapt this example and use it as a template for your own implemen
 
 ## Further Reading
 
- * [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
- * [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
- * [Docker API proxy](http://docs.weave.works/weave/latest_release/proxy.html)
+ * [How Weave Works](/documentation/net-1.5-router-topology)
+ * [Weave Features](/documentation/net-1.5-features)
+ * [Integrating Docker via the API Proxy](/documentation/net-1.5-weave-docker-api)
 
 

--- a/mesos-marathon/centos/weave.service
+++ b/mesos-marathon/centos/weave.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Weave Net
-Documentation=http://docs.weave.works/
+Documentation=http://weave.works/docs
 After=docker.service
 Before=weaveproxy.service
 Requires=docker.service

--- a/mesos-marathon/centos/weaveproxy.service
+++ b/mesos-marathon/centos/weaveproxy.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Weave Docker API proxy
-Documentation=http://docs.weave.works/
+Documentation=http://weave.works/docs
 After=docker.service
 Requires=docker.service
 [Service]

--- a/microservices-seneca-ubuntu-simple/README.md
+++ b/microservices-seneca-ubuntu-simple/README.md
@@ -149,7 +149,7 @@ vagrant@weave-gs-02:~$ weave status
 
 ####About `weavedns`
 
-[Weavedns](http://docs.weave.works/weave/latest_release/weavedns.html) answers name queries on a Weave network. It provides a simple way for containers to find each other: just give them hostnames and tell other containers to connect to those names. Unlike Docker 'links', WeaveDNS requires no code changes and it also works across hosts.
+[WeaveDNS](/documentation/net-1.5-weavedns) answers name queries on a Weave network. It provides a simple way for containers to find each other: just give them hostnames and tell other containers to connect to those names. Unlike Docker 'links', WeaveDNS requires no code changes and it also works across hosts.
 
 The seneca code was modified in this example to refer to hostnames. Each container was given a hostname and then uses `weavedns` to find the correct container for a request.
 
@@ -212,8 +212,8 @@ You can adapt this example and use it as a template for your own implementation.
 
 ##Further Reading
 
- * [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
- * [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
+ * [How Weave Works](/documentation/net-1.5-router-topology)
+ * [Weave Features](/documentation/net-1.5-features)
 
 
 ## Credits ##

--- a/nginx-ubuntu-simple/README.md
+++ b/nginx-ubuntu-simple/README.md
@@ -66,14 +66,14 @@ In this example you will give each container a hostname and use WeaveDNS to allo
 
 ## Introducing Automatic IP Address Management ##
 
-[Automatic IP Address Management(IPAM)](http://docs.weave.works/weave/latest_release/ipam.html) automatically assigns containers an IP address that is unique across the network, and releases that address when a container exit.
+[IP Address Management](/documentation/net-1.5-ipam) automatically assigns containers an IP address that is unique across the network, and releases that address when a container exit.
 
 In this example you will use IPAM to automatically allocate IP addresses to the containers used across our network. IPAM and WeaveDNS work
 seemlessly together, and you will
 
 ## Introduction Weave Proxy ##
 
-You will use the [Weave Docker API proxy](http://docs.weave.works/weave/latest_release/features.html#docker) functionality, which gives seamless integration with Docker.
+You will use the [Weave Docker API Proxy](/documentation/net-1.5-features#docker) functionality, which gives seamless integration with Docker.
 
 ## Nginx and a simple PHP application running in Apache ##
 

--- a/rails-ubuntu-simple/README.md
+++ b/rails-ubuntu-simple/README.md
@@ -182,7 +182,7 @@ documentation](https://registry.hub.docker.com/_/rails/)
 
 Weave is responsible for the raw
 network connection and also any routing between containers.
-[WeaveDNS](http://docs.weave.works/weave/latest_release/weavedns.html)
+[WeaveDNS](/documentation/net-1.5-weavedns)
 provides service-discovery between the app, and the database
 container.
 
@@ -197,7 +197,7 @@ $ eval "$(weave env)"
 ~~~
 
 >Note: In this guide commands were run directly on the host, but you can also run docker commands from your local machine on the remote host by configuring the docker client to use the [Weave Docker API
-Proxy](http://docs.weave.works/weave/latest_release/proxy.html). The Weave Docker API Proxy allows you to use the official docker client, and it will also attach any booted containers to the weave network. To enable the proxy, first install Weave on to your local machine, run `weave launch` and then set the environment by running `eval "$(weave env)"`
+Proxy](/documentation/net-1.5-weave-docker-api). The Weave Docker API Proxy allows you to use the official docker client, and it will also attach any booted containers to the weave network. To enable the proxy, first install Weave on to your local machine, run `weave launch` and then set the environment by running `eval "$(weave env)"`
 
 
 ##Launching PostgreSQL
@@ -296,6 +296,6 @@ You can adapt this example and use it as a template for your own implementation.
 
 ##Further Reading
 
- * [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
- * [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
- * [Weave Docker API Proxy](http://docs.weave.works/weave/latest_release/proxy.html)
+ * [How Weave Works](/documentation/net-1.5-router-topology)
+ * [Weave Features](/documentation/net-1.5-features)
+ * [Weave Docker API Proxy](/documentation/net-1.5-weave-docker-api)

--- a/rkt/user-data
+++ b/rkt/user-data
@@ -110,7 +110,7 @@ coreos:
       After=docker.service
       Before=weave.service
       Description=Install Weave
-      Documentation=http://docs.weave.works/
+      Documentation=http://weave.works/docs
       Requires=network-online.target
       [Service]
       EnvironmentFile=-/etc/weave.%H.env
@@ -139,7 +139,7 @@ coreos:
       After=install-weave.service
       After=docker.service
       Description=Weave proxy for Docker API
-      Documentation=http://docs.weave.works/
+      Documentation=http://weave.works/docs
       Requires=docker.service
       Requires=install-weave.service
       [Service]
@@ -158,7 +158,7 @@ coreos:
       After=install-weave.service
       After=docker.service
       Description=Weave Network Router
-      Documentation=http://docs.weave.works/
+      Documentation=http://weave.works/docs
       Requires=docker.service
       Requires=install-weave.service
       [Service]

--- a/spring-boot-weave-microservices/README.md
+++ b/spring-boot-weave-microservices/README.md
@@ -328,7 +328,7 @@ Thank-you to Chris Richardson, who graciously lent us the use of his code. For m
 
 ## Further Reading
 
-* [Documentation Home Page](http://docs.weave.works/weave/latest_release/)
-* [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
-* [Weave encryption](http://docs.weave.works/weave/latest_release/features.html#security)
-* [Weave DNS](http://docs.weave.works/weave/latest_release/weavedns.html)
+* [Documentation Home Page](/docs)
+* [Weave Features](/documentation/net-1.5-features)
+* [Weave encryption](/documentation/net-1.5-features#security)
+* [WeaveDNS](/documentation/net-1.5-weavedns)

--- a/spring-boot-weave-service-discovery/README.md
+++ b/spring-boot-weave-service-discovery/README.md
@@ -9,7 +9,7 @@ sidebarpath: /start/micro/dockerspring
 sidebarweight: 20
 ---
 
-In this tutorial you will learn how to use [`weavedns`](http://docs.weave.works/weave/latest_release/weavedns.html) to automatically discover dockerized microservices using Weave Net.  You will deploy several Spring-based microservices to Docker containers and then discover those microservices using `weavedns` without requiring any modifications to the code.
+In this tutorial you will learn how to use [WeaveDNS](/documentation/net-1.5-weavedns) to automatically discover dockerized microservices using Weave Net.  You will deploy several Spring-based microservices to Docker containers and then discover those microservices using `weavedns` without requiring any modifications to the code.
 
 You will: 
 
@@ -78,11 +78,11 @@ The IP addresses used for this demo are as follows:
 
 ####Weave and DNS
 
-The [weavedns](http://docs.weave.works/weave/latest_release/weavedns.html) service answers name queries on a Weave network. `weavedns` provides a simple way for containers to find each other by giving them hostnames and telling the other containers to connect to those names.
+The [WeaveDNS](/documentation/net-1.5-weavedns) service answers name queries on a Weave network. `weavedns` provides a simple way for containers to find each other by giving them hostnames and telling the other containers to connect to those names.
 
 ####Weave and Automatic IP Address Management
 
-[Weave Automatic IP Address Management (IPAM)](http://docs.weave.works/weave/latest_release/ipam.html) automatically assigns containers IP addresses that are unique across the network. With Weave IPAM you can easily add more containers to your network, ensuring that each container receives a unique IP.
+[Weave Automatic IP Address Management (IPAM)](/documentation/net-1.5-ipam) automatically assigns containers IP addresses that are unique across the network. With Weave IPAM you can easily add more containers to your network, ensuring that each container receives a unique IP.
 
 ## Launching Weave
 
@@ -116,7 +116,7 @@ To install and launch Weave Net manually on the host:
 
 
 >Note: In this guide commands were run directly on the host, but you can also run Docker commands from your local machine on the remote host by configuring the docker client to use the [Weave Docker API
-Proxy](http://docs.weave.works/weave/latest_release/proxy.html). The Weave Docker API Proxy allows you to use the official docker client, and it will also attach any booted containers to the weave network. To enable the proxy, first install Weave on to your local machine, run `weave launch` and then set the environment by running `eval "$(weave env)"`
+Proxy](/documentation/net-1.5-weave-docker-api). The Weave Docker API Proxy allows you to use the official docker client, and it will also attach any booted containers to the weave network. To enable the proxy, first install Weave on to your local machine, run `weave launch` and then set the environment by running `eval "$(weave env)"`
 
 ## What Just Happened
 
@@ -225,7 +225,7 @@ You can adapt this example and use it as a template for your own implementation.
 
 
 ##For Further Reading
- * [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
- * [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
- * [Naming and Discovery](http://docs.weave.works/weave/latest_release/features.html#naming-and-discovery)
- * [Address Allocation](http://docs.weave.works/weave/latest_release/features.html#addressing)
+ * [How Weave Works](/documentation/net-1.5-router-topology)
+ * [Weave Features](/documentation/net-1.5-features)
+ * [Naming and Discovery](/documentation/net-1.5-features#naming-and-discovery)
+ * [IP Address Management](/documentation/net-1.5-ipam)

--- a/ubuntu-all-in-one/README.md
+++ b/ubuntu-all-in-one/README.md
@@ -109,5 +109,5 @@ You have now used Weave to quickly deploy an application across two hosts using 
 
 ## Further Reading
 
- * [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
- * [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
+ * [How Weave Works](/documentation/net-1.5-router-topology)
+ * [Weave Features](/documentation/net-1.5-features)

--- a/ubuntu-simple/README.md
+++ b/ubuntu-simple/README.md
@@ -12,7 +12,7 @@ sidebarweight: 15
 ---
 
 
-This example demonstrates how [`weavedns`](http://docs.weave.works/weave/latest_release/weavedns.html) automatically discovers services on a `Weave` container network.
+This example demonstrates how [WeaveDNS](/documentation/net-1.5-weavedns) automatically discovers services on a `Weave` container network.
 
 In this example, you will:
 
@@ -222,5 +222,5 @@ You can adapt this example and use it as a template for your own implementation.
 
 ## Further Reading
 
- * [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
- * [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
+ * [How Weave Works](/documentation/net-1.5-router-topology)
+ * [Weave Features](/documentation/net-1.5-features)

--- a/weave-and-docker-platform/1-machine.md
+++ b/weave-and-docker-platform/1-machine.md
@@ -119,7 +119,7 @@ Running `weave launch` automatically configures your network, and it starts the 
 
 >Note: Both the `weavedns` and the `Weave Docker API Proxy` services can be started independently, if required, see `weave --help` for more information.
 
-See the [Weave Docker API Proxy documentation](http://docs.weave.works/weave/latest_release/proxy.html) for more information about the Weave Docker API proxy.
+See the [Weave Docker API Proxy documentation](/documentation/net-1.5-weave-docker-api) for more information about the Weave Docker API proxy.
 
 Now you are ready to deploy containers and also use DNS so that the containers can discover each other.
 
@@ -192,8 +192,8 @@ You can easily adapt these examples and use them as templates in your own implem
 ## Further Reading
 
   *  [Learn More About Weave](http://weave.works/articles/index.html)
-  *  [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
-  *  [Weave Docker API](http://docs.weave.works/weave/latest_release/proxy.html)
+  *  [How Weave Works](/documentation/net-1.5-router-topology)
+  *  [Weave Docker API](/documentation/net-1.5-weave-docker-api)
  
 
 [ch1]: /part-1-launching-weave-net-with-docker-machine/

--- a/weave-and-docker-platform/2-machine-weaveproxy-swarm.md
+++ b/weave-and-docker-platform/2-machine-weaveproxy-swarm.md
@@ -255,7 +255,7 @@ You can easily adapt these examples and use them as a templates in your own impl
 
 ##Further Reading
 
-  *  [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
+  *  [How Weave Works](/documentation/net-1.5-router-topology)
   *  [Automatic IP Address Management](https://github.com/weaveworks/weave/blob/master/site/ipam.md)
 
 [step1]: https://github.com/weaveworks/guides/blob/30afe999265ad18494f3a88064f70cac1edc9607/weave-and-docker-platform/scripts/1-machine-create.sh

--- a/weave-and-docker-platform/3-machine-weaveproxy-swarm-compose.md
+++ b/weave-and-docker-platform/3-machine-weaveproxy-swarm-compose.md
@@ -179,8 +179,8 @@ You can easily adapt these examples and use them as a templates in your own impl
 ##Further Reading
 
   *  [Weave -- weaving containers into applications](https://github.com/weaveworks/weave#readme)
-  *  [How Weave Works](http://docs.weave.works/weave/latest_release/how-it-works.html)
-  *  [Automatic IP Address Management](http://docs.weave.works/weave/latest_release/features.html#addressing)
+  *  [How Weave Works](/documentation/net-1.5-router-topology)
+  *  [IP Address Management](/documentation/net-1.5-ipam)
 
 
 [ch1]: /part-1-launching-weave-net-with-docker-machine/

--- a/weave-kubernetes/README.md
+++ b/weave-kubernetes/README.md
@@ -17,9 +17,9 @@ Without Weave, implementing simple networking for your app across Kubernetes clu
 
 Only after private subnets are allocated and any ports mapped, will the kube-proxy, which runs on each node, be able to forward simple TCP/UDP requests to the correct containers within a pod. And if DNS is required, an extra service must also be configured.
 
-With Weave there is no need to deploy or specify any extra services and since Weave listens on standard ports, mapping ports is also not required. Using the [Weave Docker API Proxy](http://docs.weave.works/weave/latest_release/proxy.html), Weave takes care of [IP management with IPAM](http://docs.weave.works/weave/latest_release/ipam.html) and also [Automatic Service Discovery](http://docs.weave.works/weave/latest_release/features.html#naming-and-discovery), with the `weaveDNS` service which removes the requirement of having to directly configure the Docker daemon with statically allocated private subnets for each host or node.
+With Weave there is no need to deploy or specify any extra services and since Weave listens on standard ports, mapping ports is also not required. Using the [Weave Docker API Proxy](/documentation/net-1.5-weave-docker-api), Weave takes care of [IP management with IPAM](/documentation/net-1.5-ipam) and also [Discovering Containers with WeaveDNS](/documentation/net-1.5-weavedns), with the `weaveDNS` service which removes the requirement of having to directly configure the Docker daemon with statically allocated private subnets for each host or node.
 
-In addition to those services, Weave provides simple to deploy [encryption](http://docs.weave.works/weave/latest_release/features.html#security) and is one of the few solutions that can integrate with non-containerized services, such as legacy databases, and manage those services together on a container network.
+In addition to those services, Weave provides simple to deploy [encryption](/documentation/net-1.5-features#security) and is one of the few solutions that can integrate with non-containerized services, such as legacy databases, and manage those services together on a container network.
 
 Because Weave is an integrated and dedicated container network solution, overhead costs and resource complexity is reduced. Weave in essence saves you time and money, and lets you focus on app development, rather than your infrastructure design.
 
@@ -367,8 +367,8 @@ The purpose of this guide is to provide an out-of-the-box implementation that ca
 
 ## Further Reading
 
-* [Documentation Home Page](http://docs.weave.works/weave/latest_release/)
+* [Documentation Home Page](/docs)
 * [How Weave Works](https://github.com/weaveworks/weave)
-* [Weave Features](http://docs.weave.works/weave/latest_release/features.html)
-* [Weave encryption](http://docs.weave.works/weave/latest_release/features.html#security)
-* [Weave IPAM](http://docs.weave.works/weave/latest_release/features.html#addressing)
+* [Weave Features](/documentation/net-1.5-features)
+* [Weave encryption](/documentation/net-1.5-features#security)
+* [Weave IPAM](/documentation/net-1.5-features#addressing)

--- a/weave-loadbalance/README.md
+++ b/weave-loadbalance/README.md
@@ -93,9 +93,9 @@ The `setup-weave.sh` script automates this process for you as well.
 
 Unlike Docker ‘ambassador links’, `weavedns` requires no code changes and it also works across hosts. 
 
-See [Automatic Discovery with weavedns](http://docs.weave.works/weave/latest_release/weavedns.html) for information about how the weavedns service works.
+See [Discovering Containers with WeaveDNS](/documentation/net-1.5-weavedns) for information about how the weavedns service works.
 
-[Weave Automatic IP Address Management (IPAM)](http://docs.weave.works/weave/latest_release/ipam.html) automatically assigns any new containers a unique IP address across the network. With Weave IPAM you can add more containers to the network without having to worry about manually assigning each a unique IP.
+[Weave Automatic IP Address Management (IPAM)](/documentation/net-1.5-ipam) automatically assigns any new containers a unique IP address across the network. With Weave IPAM you can add more containers to the network without having to worry about manually assigning each a unique IP.
 
 ####Checking the Weave Network
 
@@ -234,4 +234,4 @@ You can adapt this example and use it as a template for your own implementation.
 
 * [Automatic Discovery with weavedns](https://github.com/weaveworks/weave/blob/master/site/weavedns.md)
 * [Weave - Weaving Containers into Applications](https://github.com/weaveworks/weave)
-* [Documentation Home Page](http://docs.weave.works/weave/latest_release/)
+* [Documentation Home Page](/docs)


### PR DESCRIPTION
Assuming a version of 1.5 for now; will come up with a solution for stable links (e.g. a floating 'latest' version) later.
